### PR TITLE
SVCPLAN-2149: Refactor gpfs::install::yumrepo, updated pkg_list for RHEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ GSSAPIAuthentication no
 ## Install gpfs client, join the gpfs cluster
 * `include gpfs`
 #### Required Parameters:
-* `gpfs::install::yumrepo_baseurl` (STRING)
-    * The baseurl of the yum repo from which to install gpfs modules.
-    * Note: GPFS rpm's (historically) don't provide sufficient dependency information.
-      Additionally, sometimes only some rpm pkg's update between versions.
-      Therefore, this package assumes the Yum Repo baseurl is single, specific gpfs version.
-      Likewise, the gpfs version to install is managed by changing this URL.
+* `gpfs::install::yumrepo` (HASH)
+    * Data for a yumrepo from which to install gpfs packages.
+    * Note: GPFS RPMs (historically) don't provide sufficient dependency information.
+      Additionally, sometimes only some RPM pkgs update between versions.
+      Therefore, this package assumes the yumrepo baseurl is single, specific gpfs version.
+      Likewise, the gpfs version to install is managed by changing the data for this yumrepo resource.
 * `gpfs::firewall::allow_from` (ARRAY)
     * Array of Strings representing ip addresses of nodes that participate in the gpfs cluster.
     * Supported formats are

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,40 +9,23 @@
 * [`gpfs`](#gpfs): NCSA Spectrum Scale Puppet Module (formerly GPFS)    @summary   This module will install the latest version of GPFS for the specified   yum r
 * [`gpfs::add_client`](#gpfsadd_client): Add this node to the gpfs cluster
 * [`gpfs::bindmounts`](#gpfsbindmounts): Create bindmounts as specified in Hiera
-* [`gpfs::cron`](#gpfscron): Install cron jobs for:    - Exempt gpfs from linux kernel OOM killer    - (OPTIONAL) accept license for all nodes in cluster  Parameters:    
-* [`gpfs::firewall`](#gpfsfirewall): Parameters:     allow_from - allow incoming traffic from these sources                  on GPFS specific tcp ports
+* [`gpfs::cron`](#gpfscron): Install cron jobs for:    - Exempt gpfs from linux kernel OOM killer    - (OPTIONAL) accept license for all nodes in cluster  Parameters:
+* [`gpfs::firewall`](#gpfsfirewall)
 * [`gpfs::install`](#gpfsinstall): Manage a gpfs yum repo (optional) & Install GPFS
-Parameters:
-  yumrepo_baseurl - Yum repo from which to install gpfs client packages
-                    This will control the version of gpfs
-                    Set this to empty string to disable yumrepo management
-  pkg_list        - OPTIONAL
-                    list of dependent OS packages to install
-                    default value defined in module hiera
 * [`gpfs::nativemounts`](#gpfsnativemounts): Mount all specified GPFS filesystems
-* [`gpfs::quota`](#gpfsquota): NCSA custom quota command   @summary  Override native gpfs quota command with a script that will  invoke a custom quota command on the gpfs s
-* [`gpfs::startup`](#gpfsstartup): @summary  Start GPFS and wait for verification that it started successfully  PARAMETERS    cmds - OPTIONAL           default values set in mo
+* [`gpfs::quota`](#gpfsquota): Override native gpfs quota command with a script that will
+invoke a custom quota command on the gpfs server specified by
+$host on $port.
+* [`gpfs::startup`](#gpfsstartup): Start GPFS and wait for verification that it started successfully
 
 ### Defined types
 
-* [`gpfs::bindmount`](#gpfsbindmount): Create a bindmount  Note: this defined type is not intended to be invoked directly,       but rather via gpfs::bindmounts  PARAMETERS:   (nam
+* [`gpfs::bindmount`](#gpfsbindmount): Defined type, not intended to be invoked directly, but rather via
+gpfs::bindmounts. The name of the resource is the target mountpath.
 * [`gpfs::nativemount`](#gpfsnativemount): Create mount options file, populated with specified options
 Ensure parent (mountpoint) directory exists
 Ensure the filesystem is mounted
-
 Name: gpfs filesystem name
-Parameters:
-  opts       - OPTIONAL
-               comma separated string of additional mount options
-               defaults to 'noauto'
-               note: 'noauto' will always be included in the options
-                     (cannot be overridden)
-  mountpoint - OPTIONAL
-               where the filesystem is mounted at
-               defaults to '/FSNAME', where FSNAME is replaced with the
-               gpfs filesystem name
-               note: this must match the mountpoint specified in the gpfs
-                     filesystem configuration (ie: mmlsfs)
 
 ## Classes
 
@@ -55,10 +38,14 @@ NCSA Spectrum Scale Puppet Module (formerly GPFS)
   yum repository.  GPFS version is thus controlled by yumrepo_baseurl.
 
   Parameters:
-      resource_defaults - OPTIONAL
-                          default values set in module hiera
-  @example
-      include gpfs
+
+#### Examples
+
+##### 
+
+```puppet
+include gpfs
+```
 
 #### Parameters
 
@@ -70,7 +57,7 @@ The following parameters are available in the `gpfs` class:
 
 Data type: `Hash[String[1], Hash[String[1], Data, 1], 1]`
 
-
+OPTIONAL - default values set in module hiera
 
 ### <a name="gpfsadd_client"></a>`gpfs::add_client`
 
@@ -165,14 +152,6 @@ Create bindmounts as specified in Hiera
 ```puppet
 This class is already included by gpfs::init, so just need to specify,
 in hiera, the list of bindmounts and associated data.
-
-HIERA
----
-gpfs::bindmounts::mountmap:
-    /scratch:
-        opts: nosuid
-        src_path:  /lsst/scratch
-        src_mountpoint: /lsst
 ```
 
 #### Parameters
@@ -185,7 +164,13 @@ The following parameters are available in the `gpfs::bindmounts` class:
 
 Data type: `Hash`
 
-
+HIERA
+---
+gpfs::bindmounts::mountmap:
+    /scratch:
+        opts: nosuid
+        src_path:  /lsst/scratch
+        src_mountpoint: /lsst
 
 Default value: `{}`
 
@@ -196,7 +181,6 @@ Install cron jobs for:
    - (OPTIONAL) accept license for all nodes in cluster
 
 Parameters:
-    accept_license - Boolean - install cron script to auto accept license
 
 #### Parameters
 
@@ -208,13 +192,11 @@ The following parameters are available in the `gpfs::cron` class:
 
 Data type: `Boolean`
 
-
+Install cron script to auto accept license
 
 ### <a name="gpfsfirewall"></a>`gpfs::firewall`
 
-Parameters:
-    allow_from - allow incoming traffic from these sources
-                 on GPFS specific tcp ports
+The gpfs::firewall class.
 
 #### Parameters
 
@@ -226,37 +208,32 @@ The following parameters are available in the `gpfs::firewall` class:
 
 Data type: `Array[String[1], 1]`
 
-
+Allow incoming traffic from these sources on GPFS specific tcp
+ports.
 
 ### <a name="gpfsinstall"></a>`gpfs::install`
 
 Manage a gpfs yum repo (optional) & Install GPFS
-Parameters:
-  yumrepo_baseurl - Yum repo from which to install gpfs client packages
-                    This will control the version of gpfs
-                    Set this to empty string to disable yumrepo management
-  pkg_list        - OPTIONAL
-                    list of dependent OS packages to install
-                    default value defined in module hiera
 
 #### Parameters
 
 The following parameters are available in the `gpfs::install` class:
 
-* [`yumrepo_baseurl`](#yumrepo_baseurl)
+* [`yumrepo`](#yumrepo)
 * [`pkg_list`](#pkg_list)
 
-##### <a name="yumrepo_baseurl"></a>`yumrepo_baseurl`
+##### <a name="yumrepo"></a>`yumrepo`
 
-Data type: `String`
+Data type: `Hash`
 
-
+Hash of yumrepo parameters in form of yumrepo parameters
 
 ##### <a name="pkg_list"></a>`pkg_list`
 
 Data type: `Array[String[1], 1]`
 
-
+OPTIONAL - List of dependent OS packages to install. Default value defined
+in module hiera.
 
 ### <a name="gpfsnativemounts"></a>`gpfs::nativemounts`
 
@@ -269,12 +246,6 @@ Mount all specified GPFS filesystems
 ```puppet
 This class is already included from gpfs::init, so just need to
 specify, in hiera, which filesystems to mount
-
-HIERA
----
-gpfs::nativemounts::mountmap:
-    lsst:
-        opts: ro
 ```
 
 #### Parameters
@@ -287,18 +258,17 @@ The following parameters are available in the `gpfs::nativemounts` class:
 
 Data type: `Hash`
 
-
+HIERA
+---
+gpfs::nativemounts::mountmap:
+    lsst:
+        opts: ro
 
 Default value: `{}`
 
 ### <a name="gpfsquota"></a>`gpfs::quota`
 
 NCSA custom quota command
-
- @summary
- Override native gpfs quota command with a script that will
- invoke a custom quota command on the gpfs server specified by
- $host on $port.
 
 #### Parameters
 
@@ -311,21 +281,17 @@ The following parameters are available in the `gpfs::quota` class:
 
 Data type: `String[1]`
 
-
+Host that should be used for custom quota command.
 
 ##### <a name="port"></a>`port`
 
 Data type: `Integer[1, 65535]`
 
-
+Port on the custom quota host.
 
 ### <a name="gpfsstartup"></a>`gpfs::startup`
 
-@summary
- Start GPFS and wait for verification that it started successfully
- PARAMETERS
-   cmds - OPTIONAL
-          default values set in module hiera
+Start GPFS and wait for verification that it started successfully
 
 #### Parameters
 
@@ -337,25 +303,13 @@ The following parameters are available in the `gpfs::startup` class:
 
 Data type: `Hash[String[1], String[1], 2, 2]`
 
-
+OPTIONAL - default values set in module hiera
 
 ## Defined types
 
 ### <a name="gpfsbindmount"></a>`gpfs::bindmount`
 
 Create a bindmount
-
-Note: this defined type is not intended to be invoked directly,
-      but rather via gpfs::bindmounts
-
-PARAMETERS:
-  (name)         - The target mountpath of this bindmount
-                   (ie: the directory path users will see)
-  src_path       - The source of this bindmount
-                   (ie: the directory this bindmount will point to)
-  src_mountpoint - The mountpath of the gpfs filesystem
-                   that this bindmount depends on
-  opts           - Comma separated list of mount options
 
 #### Parameters
 
@@ -369,19 +323,21 @@ The following parameters are available in the `gpfs::bindmount` defined type:
 
 Data type: `String[1]`
 
-
+The source of this bindmount (ie: the directory this bindmount will point
+to).
 
 ##### <a name="src_mountpoint"></a>`src_mountpoint`
 
 Data type: `String[1]`
 
-
+The mountpath of the gpfs filesystem that this bindmount depends
+on
 
 ##### <a name="opts"></a>`opts`
 
 Data type: `String`
 
-
+Comma separated list of mount options.
 
 Default value: `''`
 
@@ -413,7 +369,9 @@ The following parameters are available in the `gpfs::nativemount` defined type:
 
 Data type: `Any`
 
-
+OPTIONAL - Comma separated string of additional mount options.
+Defaults to 'noauto'. Note: 'noauto' will always be included in the
+options (cannot be overridden).
 
 Default value: `''`
 
@@ -421,7 +379,9 @@ Default value: `''`
 
 Data type: `Any`
 
-
+OPTIONAL - Where the filesystem is mounted at defaults to '/FSNAME', where
+FSNAME is replaced with the gpfs filesystem name. Note: this must match
+the mountpoint specified in the gpfs filesystem configuration (ie: mmlsfs).
 
 Default value: `''`
 

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,7 +1,17 @@
 ---
+gpfs::install::yumrepo:
+  name: "gpfs"
+  ensure: "present"
+  #baseurl: "https://<yum-server>/repos/GPFS/5.0.1.1/gpfs_rpms"   # MUST BE SET
+  descr: "IBM Spectrum Scale GPFS - $basearch"
+  enabled: true
+  gpgcheck: false
+  #gpgkey: ""
+
 gpfs::install::pkg_list:
   - "gcc-c++"
   - "gpfs.base"
+  - "gpfs.compression"
   - "gpfs.docs"
   - "gpfs.gpl"
   - "gpfs.gskit"
@@ -9,3 +19,4 @@ gpfs::install::pkg_list:
   - "kernel-devel"
   - "kernel-headers"
   - "libstdc++"
+  - "m4"

--- a/manifests/add_client.pp
+++ b/manifests/add_client.pp
@@ -107,6 +107,18 @@ class gpfs::add_client (
       ;
     }
   }
+  else
+  {
+    exec {
+      'rm_gpfs_add_client_sh':
+        command => "/bin/rm -f ${script_tgt_fn}",
+        onlyif  => "test -f ${script_tgt_fn}",
+      ;
+      default:
+        * => $gpfs::resource_defaults['exec']
+      ;
+    }
+  }
 
   # AUTHORIZE SSH FROM GPFS MASTER
   ssh_authorized_key { 'gpfs_master_authorized_key':

--- a/manifests/bindmount.pp
+++ b/manifests/bindmount.pp
@@ -11,7 +11,8 @@
 # @param src_mountpoint
 #   The mountpath of the gpfs filesystem that this bindmount depends
 #   on
-# @param ops
+#
+# @param opts
 #   Comma separated list of mount options.
 #
 define gpfs::bindmount(

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,27 +1,28 @@
 # @summary
 #   Manage a gpfs yum repo (optional) & Install GPFS
 #
-# @param yumrepo_baseurl
-#   Yum repo from which to install gpfs client packages. This will control the
-#   version of gpfs. Set this to empty string to disable yumrepo management.
+# @param yumrepo
+#   Hash of yumrepo parameters in form of yumrepo parameters
+#
 # @param pkg_list
 #   OPTIONAL - List of dependent OS packages to install. Default value defined
 #   in module hiera.
 #
 class gpfs::install (
-  String              $yumrepo_baseurl,
+  Hash                $yumrepo,
   Array[String[1], 1] $pkg_list,
 ) {
 
   # INSTALL THE YUM REPO (if provided)
-  if $yumrepo_baseurl =~ String[1] {
-    yumrepo { 'puppet-gpfs':
-      ensure   => present,
-      baseurl  => $yumrepo_baseurl,
-      descr    => 'Puppet Spectrum Scale',
-      enabled  => 1,
-      gpgcheck => 0,
+  if ( ! empty($yumrepo) ) {
+    yumrepo { 'gpfs':
+      * => $yumrepo,
     }
+  }
+
+  # REMOVE OLD VERSION OF REPO
+  yumrepo { 'puppet-gpfs':
+    ensure => absent,
   }
 
   # GPFS profile.d PATH SCRIPT

--- a/manifests/startup.pp
+++ b/manifests/startup.pp
@@ -1,10 +1,8 @@
-###
-#  @summary
-#  Start GPFS and wait for verification that it started successfully
-#  PARAMETERS
-#    cmds - OPTIONAL
-#           default values set in module hiera
-###
+# @summary
+#   Start GPFS and wait for verification that it started successfully
+#
+# @param cmds
+#   OPTIONAL - default values set in module hiera
 #
 class gpfs::startup (
   Hash[String[1], String[1], 2, 2] $cmds,


### PR DESCRIPTION
```
Refactor gpfs::install::yumrepo to replace yumrepo_baseurl
Updated gpfs::install::pkg_list for RHEL
Ensure gpfs_add_client_sh script is always removed
```

Goal here is to provide a more configurable yum repo for GPFS. Need to be able to support gpgkeys, etc.

I do not have a way to test this. Suggest we sync a copy into ache-repo to test with mForge.