### PR TITLE
Remove reference to LSST

### DIFF
--- a/manifests/add_client.pp
+++ b/manifests/add_client.pp
@@ -124,7 +124,8 @@ class gpfs::add_client (
   ssh_authorized_key { 'gpfs_master_authorized_key':
     user => 'root',
     type => 'ssh-rsa',
-    name => 'root@lsst_gpfs',
+    #name => "root@${master_server}",
+    name => 'root@gpfs',
     key  => $ssh_public_key_contents,
   }
 


### PR DESCRIPTION
This has not been tested.  But it is a pretty trivial change.

This is changing the entry in `/root/.ssh/authorized_keys` to no longer have a comment of `root@lsst_gpfs`. Instead it is being hard coded to be `root@gpfs`.

As an alternative we could make the comment be `root@${master_server}`, but I was not convinced that is as obvious if that parameter is an IP address or a FQDN that is not obvious to be a GPFS server.