### PR TITLE
SVCPLAN-8525: Add timeout to gpfs_client_health.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /spec/fixtures/modules/*
 /tmp/
 /vendor/
+/.vendor/
 /convert_report.txt
 /update_report.txt
 .DS_Store
@@ -26,3 +27,9 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.resource_types
+.modules
+.task_cache.json
+.plan_cache.json
+.rerun.json
+bolt-debug.log

--- a/.pdkignore
+++ b/.pdkignore
@@ -19,6 +19,7 @@
 /spec/fixtures/modules/*
 /tmp/
 /vendor/
+/.vendor/
 /convert_report.txt
 /update_report.txt
 .DS_Store
@@ -26,6 +27,12 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.resource_types
+.modules
+.task_cache.json
+.plan_cache.json
+.rerun.json
+bolt-debug.log
 /.fixtures.yml
 /Gemfile
 /.gitattributes

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,9 @@
+--fail-on-warnings
 --relative
+--no-80chars-check
+--no-140chars-check
+--no-class_inherits_from_params_class-check
+--no-autoloader_layout-check
+--no-documentation-check
+--no-single_quote_string_with_variables-check
+--ignore-paths=.vendor/**/*.pp,.bundle/**/*.pp,pkg/**/*.pp,spec/**/*.pp,tests/**/*.pp,types/**/*.pp,vendor/**/*.pp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require:
 - rubocop-performance
 - rubocop-rspec
 AllCops:
+  NewCops: enable
   DisplayCopNames: true
   TargetRubyVersion: '2.6'
   Include:
@@ -527,6 +528,8 @@ Lint/DuplicateBranch:
   Enabled: false
 Lint/DuplicateMagicComment:
   Enabled: false
+Lint/DuplicateMatchPattern:
+  Enabled: false
 Lint/DuplicateRegexpCharacterClassElement:
   Enabled: false
 Lint/EmptyBlock:
@@ -643,6 +646,8 @@ Style/ComparableClamp:
   Enabled: false
 Style/ConcatArrayLiterals:
   Enabled: false
+Style/DataInheritance:
+  Enabled: false
 Style/DirEmpty:
   Enabled: false
 Style/DocumentDynamicEvalDefinition:
@@ -710,6 +715,8 @@ Style/RedundantEach:
 Style/RedundantHeredocDelimiterQuotes:
   Enabled: false
 Style/RedundantInitialize:
+  Enabled: false
+Style/RedundantLineContinuation:
   Enabled: false
 Style/RedundantSelfAssignmentBranch:
   Enabled: false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "puppet.puppet-vscode",
-    "rebornix.Ruby"
+    "Shopify.ruby-lsp"
   ]
 }

--- a/Gemfile
+++ b/Gemfile
@@ -20,30 +20,31 @@ group :development do
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "deep_merge", '~> 1.2.2',                  require: false
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
-  gem "facterdb", '~> 1.18',                     require: false
-  gem "metadata-json-lint", '~> 3.0',            require: false
-  gem "puppetlabs_spec_helper", '~> 6.0',        require: false
-  gem "rspec-puppet-facts", '~> 2.0',            require: false
-  gem "codecov", '~> 0.2',                       require: false
+  gem "facterdb", '~> 2.1',                      require: false
+  gem "metadata-json-lint", '~> 4.0',            require: false
+  gem "rspec-puppet-facts", '~> 4.0',            require: false
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false
-  gem "simplecov-console", '~> 0.5',             require: false
+  gem "simplecov-console", '~> 0.9',             require: false
   gem "puppet-debugger", '~> 1.0',               require: false
-  gem "rubocop", '= 1.48.1',                     require: false
+  gem "rubocop", '~> 1.50.0',                    require: false
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
-  gem "puppet-strings", '~> 4.0',                require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "rexml", '>= 3.0.0', '< 3.2.7',            require: false
+end
+group :development, :release_prep do
+  gem "puppet-strings", '~> 4.0',         require: false
+  gem "puppetlabs_spec_helper", '~> 8.0', require: false
+  gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
-  gem "serverspec", '~> 2.41',   require: false
-end
-group :release_prep do
-  gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 6.0', require: false
+  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw]
+  gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "serverspec", '~> 2.41',     require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -4,85 +4,15 @@ require 'bundler'
 require 'puppet_litmus/rake_tasks' if Gem.loaded_specs.key? 'puppet_litmus'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
-require 'github_changelog_generator/task' if Gem.loaded_specs.key? 'github_changelog_generator'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 
-def changelog_user
-  return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = nil || JSON.load(File.read('metadata.json'))['author']
-  raise "unable to find the changelog_user in .sync.yml, or the author in metadata.json" if returnVal.nil?
-  puts "GitHubChangelogGenerator user:#{returnVal}"
-  returnVal
-end
-
-def changelog_project
-  return unless Rake.application.top_level_tasks.include? "changelog"
-
-  returnVal = nil
-  returnVal ||= begin
-    metadata_source = JSON.load(File.read('metadata.json'))['source']
-    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
-
-    metadata_source_match && metadata_source_match[1]
-  end
-
-  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
-
-  puts "GitHubChangelogGenerator project:#{returnVal}"
-  returnVal
-end
-
-def changelog_future_release
-  return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = "v%s" % JSON.load(File.read('metadata.json'))['version']
-  raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
-  puts "GitHubChangelogGenerator future_release:#{returnVal}"
-  returnVal
-end
-
 PuppetLint.configuration.send('disable_relative')
-
-
-if Gem.loaded_specs.key? 'github_changelog_generator'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
-    config.user = "#{changelog_user}"
-    config.project = "#{changelog_project}"
-    config.future_release = "#{changelog_future_release}"
-    config.exclude_labels = ['maintenance']
-    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
-    config.add_pr_wo_labels = true
-    config.issues = false
-    config.merge_prefix = "### UNCATEGORIZED PRS; LABEL THEM ON GITHUB"
-    config.configure_sections = {
-      "Changed" => {
-        "prefix" => "### Changed",
-        "labels" => ["backwards-incompatible"],
-      },
-      "Added" => {
-        "prefix" => "### Added",
-        "labels" => ["enhancement", "feature"],
-      },
-      "Fixed" => {
-        "prefix" => "### Fixed",
-        "labels" => ["bug", "documentation", "bugfix"],
-      },
-    }
-  end
-else
-  desc 'Generate a Changelog from GitHub'
-  task :changelog do
-    raise <<EOM
-The changelog tasks depends on recent features of the github_changelog_generator gem.
-Please manually add it to your .sync.yml for now, and run `pdk update`:
----
-Gemfile:
-  optional:
-    ':development':
-      - gem: 'github_changelog_generator'
-        version: '~> 1.15'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
-EOM
-  end
-end
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+PuppetLint.configuration.send('disable_autoloader_layout')
+PuppetLint.configuration.send('disable_documentation')
+PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.ignore_paths = [".vendor/**/*.pp", ".bundle/**/*.pp", "pkg/**/*.pp", "spec/**/*.pp", "tests/**/*.pp", "types/**/*.pp", "vendor/**/*.pp"]
 

--- a/files/telegraf/gpfs_client_health.sh
+++ b/files/telegraf/gpfs_client_health.sh
@@ -85,7 +85,7 @@ if [ -d /usr/lpp/mmfs/bin ]; then
       proc_check=1
     fi
     mpoint=$(grep gpfs /etc/fstab | grep -v bind | grep ${f} | awk '{print $2}')
-    stat=$(stat ${mpoint}/.SETcheck)
+    stat=$(timeout 20s stat ${mpoint}/.SETcheck)
     if [ -n "$stat" ]; then
       #We can stat a file
       stat_check=0

--- a/manifests/add_client.pp
+++ b/manifests/add_client.pp
@@ -49,7 +49,6 @@ class gpfs::add_client (
   String[1] $ssh_public_key_contents,
   String[1] $ssh_public_key_type,
 ) {
-
   include gpfs::startup
 
   # AUTHORIZE SSH FROM GPFS MASTER
@@ -70,8 +69,7 @@ class gpfs::add_client (
   }
 
   # SKIP ADD CLIENT IF NODE IS ALREADY PART OF A GPFS CLUSTER
-  if ! $facts['is_gpfs_member_node']
-  {
+  if ! $facts['is_gpfs_member_node'] {
     # GET IP OF GPFS INTERFACE
     if ( ! empty( $interface ) ) {
       $gpfs_ip_address = $facts['networking']['interfaces'][$interface]['ip']
@@ -87,21 +85,21 @@ class gpfs::add_client (
         group   => root,
         mode    => '0700',
         content => epp('gpfs/add_client.epp', {
-          'hostname'                 => $facts['hostname'],
-          'gpfs_master'              => $master_server,
-          'ipaddress'                => $gpfs_ip_address,
-          'nodeclasses'              => $nodeclasses,
-          'pagepool'                 => $pagepool,
-          'pagepool_max_ram_percent' => $pagepool_max_ram_percent,
-          'script_fn'                => $script_tgt_fn,
-          'ssh_private_key_contents' => $ssh_private_key_contents,
-          'ssh_private_key_path'     => $ssh_private_key_path,
+            'hostname'                 => $facts['hostname'],
+            'gpfs_master'              => $master_server,
+            'ipaddress'                => $gpfs_ip_address,
+            'nodeclasses'              => $nodeclasses,
+            'pagepool'                 => $pagepool,
+            'pagepool_max_ram_percent' => $pagepool_max_ram_percent,
+            'script_fn'                => $script_tgt_fn,
+            'ssh_private_key_contents' => $ssh_private_key_contents,
+            'ssh_private_key_path'     => $ssh_private_key_path,
           }
         ),
-      ;
+        ;
       default:
         * => $gpfs::resource_defaults['file']
-      ;
+        ;
     }
 
     # EXECUTE ADD CLIENT SCRIPT
@@ -111,39 +109,38 @@ class gpfs::add_client (
         creates => $mmsdrfs,
         onlyif  => "/usr/bin/test ! -e ${gpfs::startup::no_gpfs_file}",
         require => [
-          File[ $script_tgt_fn ],
-          Class[ 'gpfs' ],
-          Ssh_authorized_key[ 'gpfs_master_authorized_key' ],
-          Firewall[  '100 ssh from gpfs master' ],
+          File[$script_tgt_fn],
+          Class['gpfs'],
+          Ssh_authorized_key['gpfs_master_authorized_key'],
+          Firewall['100 ssh from gpfs master'],
         ],
         notify  => [
-          Class[ 'gpfs::startup' ],
-          Exec[ 'rm_gpfs_add_client_sh' ],
-          File[ $ssh_private_key_path ],
+          Class['gpfs::startup'],
+          Exec['rm_gpfs_add_client_sh'],
+          File[$ssh_private_key_path],
         ],
-      ;
+        ;
       'rm_gpfs_add_client_sh':
         command => "/bin/rm -f ${script_tgt_fn}",
         require => [
-          File[ $script_tgt_fn ],
-          Exec[ 'gpfs_add_client' ],
+          File[$script_tgt_fn],
+          Exec['gpfs_add_client'],
         ]
-      ;
+        ;
       default:
         * => $gpfs::resource_defaults['exec']
-      ;
+        ;
     }
   }
-  else
-  {
+  else {
     exec {
       'rm_gpfs_add_client_sh':
         command => "/bin/rm -f ${script_tgt_fn}",
         onlyif  => "test -f ${script_tgt_fn}",
-      ;
+        ;
       default:
         * => $gpfs::resource_defaults['exec']
-      ;
+        ;
     }
   }
 
@@ -154,5 +151,4 @@ class gpfs::add_client (
   file { $ssh_private_key_path:
     ensure => absent,
   }
-
 }

--- a/manifests/bindmount.pp
+++ b/manifests/bindmount.pp
@@ -15,20 +15,18 @@
 # @param opts
 #   Comma separated list of mount options.
 #
-define gpfs::bindmount(
+define gpfs::bindmount (
   String[1] $src_path,
   String[1] $src_mountpoint,
   String    $opts = '',
-)
-{
-#    notify {"gpfs::bindmount ${name}":}
+) {
+  # notify { "gpfs::bindmount ${name}": }
 
   # Resource defaults
   $dir_defaults = merge(
     $gpfs::resource_defaults['file'],
     { 'ensure' => 'directory' }
-  ).delete( [ 'mode', 'group', 'owner' ] )
-
+  ).delete(['mode', 'group', 'owner'])
 
   # Build mount option string
   $defaultopts = 'bind,noauto'
@@ -39,12 +37,11 @@ define gpfs::bindmount(
     $optstr = $defaultopts
   }
 
-
   # Ensure parents of target dir exist, if needed (excluding / )
   $dirparts = reject( split( $name, '/' ), '^$' )
   $numparts = size( $dirparts )
   if ( $numparts > 1 ) {
-    each( Integer[2,$numparts] ) |$i| {
+    each(Integer[2,$numparts]) |$i| {
       ensure_resource(
         'file',
         reduce( Integer[2,$i], $name ) |$memo, $val| { dirname( $memo ) },
@@ -53,17 +50,15 @@ define gpfs::bindmount(
     }
   }
 
-
   # Remove mode from defaults so that existing tgt mount won't be affected
   # otherwise might change perms on target mountpoint
   file {
     # Ensure target directory exists
     $name:
-    ;
+      ;
     default: * => $dir_defaults
     ;
   }
-
 
   # Define the bind mount point
   mount {
@@ -71,12 +66,11 @@ define gpfs::bindmount(
       device  => $src_path,
       options => $optstr,
       require => [
-        File[ $name ],
-        Exec[ "mmmount ${src_mountpoint}" ],
+        File[$name],
+        Exec["mmmount ${src_mountpoint}"],
       ],
-    ;
+      ;
     default: * => $gpfs::resource_defaults['mount']
     ;
   }
-
 }

--- a/manifests/bindmounts.pp
+++ b/manifests/bindmounts.pp
@@ -18,9 +18,7 @@
 class gpfs::bindmounts (
   Hash $mountmap = {},
 ) {
-
   $mountmap.each | $k, $v | {
-    gpfs::bindmount{ $k: * => $v }
+    gpfs::bindmount { $k: * => $v }
   }
-
 }

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -10,7 +10,6 @@
 class gpfs::cron (
   Boolean $accept_license,
 ) {
-
   # CRON FILE LOCATIONS
   $root_cron       = '/root/cron'
   $fn_gpfs_oom     = "${root_cron}/gpfs_oom.sh"
@@ -33,10 +32,10 @@ class gpfs::cron (
     $fn_gpfs_oom :
       source => "puppet:///modules/gpfs${fn_gpfs_oom}",
       mode   => '0700',
-    ;
+      ;
     default:
       * => $gpfs::resource_defaults['file']
-    ;
+      ;
   }
   cron {
     'gpfs_oom' :
@@ -44,10 +43,10 @@ class gpfs::cron (
       command => $fn_gpfs_oom,
       hour    => 0,
       minute  => 2,
-    ;
+      ;
     default:
       * => $gpfs::resource_defaults['cron']
-    ;
+      ;
   }
 
   # CHECK & ACCEPT LICENSE FEATURE IS OPTIONAL
@@ -62,10 +61,10 @@ class gpfs::cron (
       ensure => $license_ensure,
       source => "puppet:///modules/gpfs${fn_gpfs_license}",
       mode   => '0700',
-    ;
+      ;
     default:
       * => $gpfs::resource_defaults['file']
-    ;
+      ;
   }
   cron {
     'gpfs_license' :
@@ -73,9 +72,9 @@ class gpfs::cron (
       command => $fn_gpfs_license,
       hour    => 0,
       minute  => 1,
-    ;
+      ;
     default:
       * => $gpfs::resource_defaults['cron']
-    ;
+      ;
   }
 }

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -21,10 +21,10 @@ class gpfs::firewall (
     }
 
     # merged set of params for each firewall definition below
-    $fw_parms = merge( $common_parms, { $key => $ip_src } )
+    $fw_parms = merge($common_parms, { $key => $ip_src })
 
     # Open firewall ports
-    each( ['1191', '30000-30100'] ) |$dport| {
+    each(['1191', '30000-30100']) |$dport| {
       firewall {
         "100 gpfs ${dport} allow from ${ip_src}":
           dport => $dport,

--- a/manifests/health.pp
+++ b/manifests/health.pp
@@ -53,10 +53,8 @@ class gpfs::health (
         Service['telegraf'],
       ],
     }
-
     include profile_monitoring::telegraf
     include ::telegraf
-
   } else {
     File {
       ensure => 'absent',
@@ -94,12 +92,12 @@ class gpfs::health (
     $paths = $telegraf_script_cfg_paths
   }
   if empty($telegraf_script_cfg_files) {
-    $files = lookup('gpfs::nativemounts::mountmap', Hash) .map |$key, $value|
-      { "${value['mountpoint']}/${telegraf_script_cfg_filestat}" } .join(' ')
+    $files = lookup('gpfs::nativemounts::mountmap', Hash) .map |$key, $value| {
+      "${value['mountpoint']}/${telegraf_script_cfg_filestat}"
+    }.join(' ')
   } else {
     $files = $telegraf_script_cfg_files
   }
-
   $config_parameters = {
     fs    => $fs,
     paths => $paths,
@@ -113,16 +111,14 @@ class gpfs::health (
   file { $script_full_path :
     source  => "puppet:///modules/${module_name}/telegraf/gpfs_client_health.sh",
     mode    => '0750',
-    require => [
-      File[$script_cfg_full_path],
-    ],
+    require => File[$script_cfg_full_path],
   }
 
   # Setup telegraf config
   $telegraf_cfg_final = $telegraf_cfg + { 'command' => $script_full_path }
   telegraf::input { $file_base_name :
     plugin_type => 'exec',
-    options     => [ $telegraf_cfg_final ],
+    options     => [$telegraf_cfg_final],
     require     => File[$script_full_path],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,6 @@
 class gpfs (
   Hash[String[1], Hash[String[1], Data, 1], 1] $resource_defaults,
 ) {
-
   include gpfs::firewall
   include gpfs::install
   include gpfs::add_client
@@ -24,5 +23,4 @@ class gpfs (
   include gpfs::nativemounts
   include gpfs::bindmounts
   include gpfs::health
-
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,7 +12,6 @@ class gpfs::install (
   Hash                $yumrepo,
   Array[String[1], 1] $pkg_list,
 ) {
-
   # INSTALL THE YUM REPO (if provided)
   if ( ! empty($yumrepo) ) {
     yumrepo { 'gpfs':
@@ -29,11 +28,11 @@ class gpfs::install (
   $fn_gpfs_profile = '/etc/profile.d/gpfs.sh'
   file {
     $fn_gpfs_profile:
-      source   => "puppet:///modules/gpfs/${fn_gpfs_profile}",
-    ;
+      source => "puppet:///modules/gpfs/${fn_gpfs_profile}",
+      ;
     default:
       * => $gpfs::resource_defaults['file']
-    ;
+      ;
   }
 
   # INSTALL DEPENDENT OS PACKAGES
@@ -45,6 +44,5 @@ class gpfs::install (
   # gpfs rpm upgrade will fail while gpfs is running and this module is not
   # built to shutdown gpfs first (nor is a random gpfs shutdown a useful
   # action.)
-  ensure_packages( $pkg_list, {'ensure' => 'present'} )
-
+  ensure_packages($pkg_list, { 'ensure' => 'present' })
 }

--- a/manifests/metadata.json
+++ b/manifests/metadata.json
@@ -16,10 +16,10 @@
     {
       "operatingsystem":"CentOS",
       "operatingsystemrelease":[ "6.x", "7.x" ]
-    },
+    }
   ],
   "dependencies": [
-    { "name": "puppetlabs-stdlib", },
-    { "name": "puppetlabs-firewall", },
-  ],
+    { "name": "puppetlabs-stdlib"},
+    { "name": "puppetlabs-firewall"}
+  ]
 }

--- a/manifests/nativemount.pp
+++ b/manifests/nativemount.pp
@@ -23,18 +23,18 @@
 #       opts='ro,nosuid',
 #       mountpoint='/data' }
 #   }
-define gpfs::nativemount(
+define gpfs::nativemount (
   $opts = '',
   $mountpoint = '',
 ) {
-
   # Resource defaults
   $dir_defaults = merge(
     $gpfs::resource_defaults['file'],
-    { 'ensure' => 'directory',
+    {
+      'ensure' => 'directory',
       'mode'   => '0755',
     }
-  ).delete( [ 'mode', 'group', 'owner' ] )
+  ).delete(['mode', 'group', 'owner'])
 
   # Build mount options string
   $defaultopts = 'noauto'
@@ -50,7 +50,7 @@ define gpfs::nativemount(
   file {
     $optfile :
       content => $optstr,
-    ;
+      ;
     default: * => $gpfs::resource_defaults['file']
     ;
   }
@@ -67,7 +67,7 @@ define gpfs::nativemount(
   $dirparts = reject( split( $mpath, '/' ), '^$' )
   $numparts = size( $dirparts )
   if ( $numparts > 1 ) {
-    each( Integer[2,$numparts] ) |$i| {
+    each(Integer[2,$numparts]) |$i| {
       ensure_resource(
         'file',
         reduce( Integer[2,$i], $mpath ) |$memo, $val| { dirname( $memo ) },
@@ -79,7 +79,7 @@ define gpfs::nativemount(
   # Ensure mountpath dir exists
   file {
     $mpath:
-    ;
+      ;
     default: * => $dir_defaults
     ;
   }
@@ -95,18 +95,17 @@ define gpfs::nativemount(
     $fstab_update_cmdname:
       command => 'mmrefresh -f',
       unless  => "awk -- '${awk}' /etc/fstab"
-    ;
+      ;
     # mount (if needed)
     "mmmount ${mpath}":
       creates => "${mpath}/.MOUNTED",
       require => [
-        Class[ 'gpfs::startup' ],
-        File[ $mpath, $optfile ],
-        Exec[ $fstab_update_cmdname ],
+        Class['gpfs::startup'],
+        File[$mpath, $optfile],
+        Exec[$fstab_update_cmdname],
       ],
-    ;
+      ;
     default: * => $gpfs::resource_defaults['exec']
     ;
   }
-
 }

--- a/manifests/nativemounts.pp
+++ b/manifests/nativemounts.pp
@@ -12,12 +12,10 @@
 #       lsst:
 #           opts: ro
 #
-class gpfs::nativemounts(
+class gpfs::nativemounts (
   Hash $mountmap = {},
 ) {
-
   $mountmap.each | $k, $v | {
-    gpfs::nativemount{ $k: * => $v }
+    gpfs::nativemount { $k: * => $v }
   }
-
 }

--- a/manifests/quota.pp
+++ b/manifests/quota.pp
@@ -17,7 +17,6 @@ class gpfs::quota (
   String[1]         $host,
   Integer[1, 65535] $port,
 ) {
-
   $myquota = '/usr/local/bin/myquota'
   $symlinks = ['/usr/local/bin/mmlsquota', '/usr/local/bin/mmrepquota']
 
@@ -25,11 +24,11 @@ class gpfs::quota (
     $symlinks:
       ensure => link,
       target => $myquota,
-    ;
+      ;
     $myquota :
       content => epp( 'gpfs/myquota.epp', {
-        'host' => $host,
-        'port' => $port,
+          'host' => $host,
+          'port' => $port,
         }
       ),
       mode    => '0755',
@@ -38,5 +37,4 @@ class gpfs::quota (
       * => $gpfs::resource_defaults['file']
       ;
   }
-
 }

--- a/manifests/startup.pp
+++ b/manifests/startup.pp
@@ -11,10 +11,9 @@ class gpfs::startup (
   Hash[String[1], String[1], 2, 2] $cmds,
   String $no_gpfs_file,
 ) {
-
   exec { "${no_gpfs_file} is manually set to disable GPFS startup. Remove ${no_gpfs_file} when ready for GPFS to start.":
     command  => 'true',
-    path     =>  ['/usr/bin','/usr/sbin', '/bin'],
+    path     => ['/usr/bin', '/usr/sbin', '/bin'],
     onlyif   => "test -e ${no_gpfs_file}",
     loglevel => 'warning',
   }
@@ -23,14 +22,14 @@ class gpfs::startup (
     # START GPFS
     'mmstartup':
       command => 'mmstartup',
-      unless  => $cmds[ 'mmgetstate' ],
-      notify  => Exec[ 'mmgetstate' ],
+      unless  => $cmds['mmgetstate'],
+      notify  => Exec['mmgetstate'],
       onlyif  => "/usr/bin/test ! -e ${no_gpfs_file}",
       ;
 
     # WAIT FOR GPFS STATE TO BECOME ACTIVE (mmgetstate | grep active | wc -l)
     'mmgetstate':
-      command     => $cmds[ 'mmgetstate' ],
+      command     => $cmds['mmgetstate'],
       tries       => 4,
       try_sleep   => 10,
       refreshonly => true,
@@ -40,5 +39,4 @@ class gpfs::startup (
       * => $gpfs::resource_defaults['exec'],
       ;
   }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,7 @@
       "version_requirement": ">= 6.21.0 < 8.0.0"
     }
   ],
-  "pdk-version": "3.0.1",
-  "template-url": "pdk-default#3.0.1",
-  "template-ref": "tags/3.0.1-0-gd13288a"
+  "pdk-version": "3.4.0",
+  "template-url": "https://github.com/puppetlabs/pdk-templates#3.4.0",
+  "template-ref": "tags/3.4.0-0-gd3cc13f"
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,8 @@ default_fact_files.each do |f|
   next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
   begin
-    default_facts.merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
+    require 'deep_merge'
+    default_facts.deep_merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end
@@ -33,7 +34,7 @@ end
 
 # read default_facts and merge them over what is provided by facterdb
 default_facts.each do |fact, value|
-  add_custom_fact fact, value
+  add_custom_fact fact, value, merge_facts: true
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
This has been tested on mgrs2.

This change is attempt to address a situation in which a hanging GPFS causes the health check to timeout without sending any metrics to indicate an issue. 

In our current TIG setup, this will bypass a "No Data" alert if telegraf is otherwise healthy and sending other metrics. (This recently happened on Magnus, where the host drops off the panel during the timeframe).

My primary concern is that if there is a GPFS issue, that it might timeout somewhere earlier in the script. (Perhaps this could be mitigated by moving the proc_check/mountcheck section to the top of the script?)